### PR TITLE
Validate and update investors and learn pages

### DIFF
--- a/investors.md
+++ b/investors.md
@@ -5,17 +5,23 @@ permalink: /investors/
 ---
 
 # Venture Funding
-* [645 Ventures](https://www.645ventures.com/) (Alessio Fanelli)
+* [645 Ventures](https://www.645ventures.com/)
 * [Bessemer](https://www.bvp.com/) (Bob Goodman)
-* [boldstart](http://www.boldstart.vc/) (Ed Sim)
+* [boldstart](https://boldstart.vc/) (Ed Sim)
 * [ClearSky](http://www.clear-sky.com/) (Jay Leek)
+* [Evolution Equity Partners](https://evolutionequity.com/) (Richard Seewald)
+* [ff Venture Capital](https://ffvc.com/) (John Frankel)
 * [Flybridge](http://www.flybridge.com/) (David Aronoff)
-* [Lytical](http://www.lyticalventures.com/) (Lucas Nelson)
-* [Insight](https://www.insightpartners.com/) (Mike Triplett)
+* [Insight](https://www.insightpartners.com/) (Thomas Krane)
+* [JVP](https://jvpvc.com/) (Erel Margalit)
+* [Lux Capital](https://www.luxcapital.com/) (Josh Wolfe)
+* [Lytical](https://www.lyticalventures.com/) (Lucas Nelson)
+* [Paladin Capital Group](https://www.paladincapgroup.com/) (Rob Knake)
 * [Work-Bench](https://www.work-bench.com/) (Kelley Mak)
 
 # Accelerators
 * [Dreamit Securetech](https://www.dreamit.com/securetech)
 * [FinTech Innovation Lab](https://www.fintechinnovationlab.com/regions/apply-new-york/)
-* [Grand Central Tech](https://www.companyventures.co/grand-central-tech)
-* [VentureOut NY](https://ventureoutny.com/programs/cybersecurity/)
+* [Global Cyber Center](https://www.cybercenter.nyc/)
+* [Grand Central Tech](https://www.companyventures.com/?gct=true)
+* [NYU Tandon Future Labs](https://futurelabs.nyc/)

--- a/learn.md
+++ b/learn.md
@@ -9,9 +9,8 @@ permalink: /learn/
 ## Bootcamps
 
 * [Columbia University, by 2U](https://bootcamp.cvn.columbia.edu/cybersecurity/)
-* [Flatiron School](https://flatironschool.com/campus-and-online-cybersecurity-engineering-bootcamp/)
-* [Fullstack Cyber Academy](https://cyber.fullstackacademy.com/)
-* [The Lede Program](https://ledeprogram.com/)
+* [Flatiron School](https://flatironschool.com/courses/cybersecurity-engineering-bootcamp/)
+* [Fullstack Academy](https://www.fullstackacademy.com/programs/cybersecurity-bootcamp/)
 * [NPower](https://www.npower.org/locations/new-york/)
 * [Per Scholas](https://perscholas.org/courses/cybersecurity/cybersecurity-new-york/)
 * [Year Up](https://www.yearup.org/)
@@ -24,8 +23,8 @@ permalink: /learn/
 
 * School of Engineering and Applied Science (SEAS)
   * [Crypto Lab](https://www.cs.columbia.edu/crypto/)
-  * [Computer Architecture and Security Technologies](http://castl.cs.columbia.edu/) (CASTL)
-  * [Intrusion Detection Lab](http://ids.cs.columbia.edu/) (IDS)
+  * [Computer Architecture and Security Technologies](https://www.cs.columbia.edu/labs/castl/) (CASTL)
+  * [Intrusion Detection Systems Lab](https://ids.cs.columbia.edu/) (IDS)
   * [Security & Privacy Research Area](https://www.cs.columbia.edu/areas/security/)
 * School of International and Public Affairs (SIPA)
   * [SIPA Cyber](https://www.sipa.columbia.edu/global-research-impact/initiatives/cyber)
@@ -37,36 +36,34 @@ permalink: /learn/
 
 ## Cornell Tech
 
-* [Security Group](http://tech.cornell.edu/research/security-privacy/security-group)
+* [Security & Privacy](https://tech.cornell.edu/research/security-privacy/)
 
 ## Fordham University
 
-* School of Computer and Information Science (CIS)
-  * [Cybersecurity, MS](http://www.fordham.edu/info/25706/master_of_science_in_cybersecurity)
+* Department of Computer and Information Science (CIS)
+  * [Cybersecurity, MS](https://www.fordham.edu/academics/departments/computer-and-information-science/academic-programs/graduate-programs/master-of-science-in-cybersecurity/)
 
 ## John Jay College of Criminal Justice
 
-* [Computer Science and Information Security, BS](http://www.jjay.cuny.edu/computer-science-and-information-security-bs)
-* [Master of Science in Digital Forensics and Cybersecurity](https://www.jjay.cuny.edu/master-science-digital-forensics-and-cybersecurity) (D4CS)
+* [Computer Science and Information Security, BS](https://www.jjay.cuny.edu/academics/academic-departments/department-mathematics-computer-science/academics/computer-science-academics/bs-computer-science-information-security)
+* [Master of Science in Digital Forensics and Cybersecurity](https://www.jjay.cuny.edu/academics/graduate-programs/graduate-programs-digital-forensics-cybersecurity) (D4CS)
 
 ## New York Institute of Technology
 
-* School of Engineering & Computing Sciences
-  * [Information, Network, & Computer Security, MS](http://www.nyit.edu/degrees/information_network_computer_security)
+* College of Engineering and Computing Sciences
+  * [Cybersecurity, MS](https://www.nyit.edu/academics/degrees/cybersecurity-ms/)
 
 ## New York University
 
 * Courant Institute
   * [Analysis of Computer Systems](http://www.cs.nyu.edu/acsys/)
-* School of Engineering
+* Tandon School of Engineering
   * [Cybersecurity, MS](http://engineering.nyu.edu/academics/programs/cybersecurity-ms)
   * [OSIRIS Lab](http://osiris.cyber.nyu.edu/)
 * School of Law
-  * [Center for Law & Security](http://www.lawandsecurity.org/)
-* School of Law / School of Engineering (Joint)
+  * [Reiss Center on Law and Security](http://www.lawandsecurity.org/)
+* School of Law / Tandon School of Engineering (Joint)
   * [Cybersecurity Risk and Strategy, MS](https://cybersecurity-strategy-masters.nyu.edu/)
-* School of Professional Studies
-  * [Diploma in Cyber Security](https://www.sps.nyu.edu/professional-pathways/diplomas/technology/cybersecurity.html)
 
 ## Recurse Center
 
@@ -75,5 +72,5 @@ permalink: /learn/
 ## Stevens Institute of Technology
 
 * School of Engineering & Science
-  * [Center for Advancement of Secure Systems and Information Assurance](https://www.stevens.edu/research-entrepreneurship/research-centers-labs/center-advancement-secure-systems-and-information-assurance-cassia) (CASSIA)
+  * [Center for Advancement of Secure Systems and Information Assurance](https://www.stevens.edu/center-for-the-advancement-of-secure-systems-and-information-assurance) (CASSIA)
   


### PR DESCRIPTION
## Summary

- Researched and validated all entries on the investors and learn pages
- Updated broken/redirecting URLs to current canonical paths
- Corrected outdated program and department names
- Removed inactive or irrelevant entries
- Added new NYC cybersecurity investors and accelerators

### Investors page
- **Added VCs:** Evolution Equity Partners, ff Venture Capital, JVP, Lux Capital, Paladin Capital Group
- **Updated:** 645 Ventures (removed departed partner), boldstart (HTTPS), Insight (new partner name), Lytical (HTTPS)
- **Added accelerators:** Global Cyber Center (SOSA), NYU Tandon Future Labs
- **Updated:** Grand Central Tech URL (companyventures.co → companyventures.com)
- **Removed:** VentureOut NY (inactive since 2019)

### Learn page
- **Removed:** The Lede Program (data journalism, not cybersecurity), NYU SPS Diploma in Cyber Security (program discontinued, URL 404)
- **Updated URLs:** Flatiron School, Fullstack Academy, Columbia CASTL, Columbia IDS, Cornell Tech, Fordham, John Jay (x2), NYIT, Stevens CASSIA
- **Updated names:** Fullstack Cyber Academy → Fullstack Academy, Intrusion Detection Lab → Intrusion Detection Systems Lab, Cornell Tech Security Group → Security & Privacy, Fordham School → Department, NYIT program renamed to Cybersecurity MS, NYU School of Engineering → Tandon School of Engineering (x3), Center for Law & Security → Reiss Center on Law and Security

## Test plan
- [ ] Verify all updated URLs resolve correctly
- [ ] Check rendered markdown on GitHub preview
- [ ] Confirm no entries were accidentally dropped

🤖 Generated with [Claude Code](https://claude.com/claude-code)