### PR TITLE
Add Granitt to consulting companies

### DIFF
--- a/companies.md
+++ b/companies.md
@@ -10,6 +10,7 @@ permalink: /companies/
 
 * [BlueVoyant](https://www.bluevoyant.com/)
 * [GEM Technologies](https://gemtechnologies.net/)
+* [Granitt](https://granitt.io/)
 * [Include Security](https://www.includesecurity.com/)
 * [Kroll](https://www.kroll.com/en-us)
 * [TAG Cyber](https://www.tag-cyber.com/)


### PR DESCRIPTION
## Summary
- Add [Granitt](https://granitt.io/) to the Consulting section
- Founded by Runa Sandvik (ex-NYT, Tor Project, Freedom of the Press Foundation)
- NYC-based security consultancy protecting at-risk individuals (journalists, activists, human rights defenders) from hackers and nation-state adversaries
- Placed alphabetically between GEM Technologies and Include Security

## Test plan
- [ ] Verify link resolves to https://granitt.io/
- [ ] Confirm alphabetical ordering in Consulting section

🤖 Generated with [Claude Code](https://claude.com/claude-code)