### PR TITLE
Add Dependabot config for bundler ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      all-gems:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` covering the **bundler** ecosystem (the only dependency ecosystem in this repo)
- Configures weekly schedule with grouped updates to reduce PR noise
- No existing Dependabot config was present

## Audit findings
| Check | Status |
|-------|--------|
| Ecosystem coverage (bundler) | Added |
| Weekly schedule | Configured |
| Grouped updates | Configured |

## Test plan
- [ ] Verify Dependabot begins creating PRs after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)